### PR TITLE
Add rulefile path passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,21 @@ so 99.9% of the credit go to them
 
 ## Configuration
 
-| key                            | type          | default | description                                         |
-| ------------------------------ | ------------- | ------- | --------------------------------------------------- |
-| oelint-vscode.run.cache-path   | string        | ''      | Custom path to local caches                         |
-| oelint-vscode.run.cached       | boolean       | true    | run with local caches                               |
-| oelint-vscode.run.constantfile | string        | ''      | Path to constant file                               |
-| oelint-vscode.run.extra-layer  | array[string] | []      | Extra layer constant data to load                   |
-| oelint-vscode.run.fix          | boolean       | false   | Automatically resolve fixable issues                |
-| oelint-vscode.run.mode         | string        | fast    | Mode to run in (fast or all)                        |
-| oelint-vscode.run.nobackup     | boolean       | true    | Don't create backups files while auto fixing        |
-| oelint-vscode.run.noinfo       | boolean       | false   | No info level issues                                |
-| oelint-vscode.run.nowarn       | boolean       | false   | No warning level issues                             |
-| oelint-vscode.run.release      | string        | ''      | Yocto project release name to use (default: latest) |
-| oelint-vscode.run.rules.custom | array[string] | []      | Additional paths to search for custom rules         |
-| oelint-vscode.run.rules.nonstd | array[string] | []      | Additional non-standard rulesets to load            |
-| oelint-vscode.run.suppress     | array[string] | []      | Error IDs to suppress automatically                 |
-| oelint-vscode.update.auto      | boolean       | true    | Automatically update oelint-adv tool                |
-| oelint-vscode.update.user      | boolean       | true    | Update with --user switch                           |
+| key                            | type          | default     | description                                         |
+| ------------------------------ | ------------- | ----------- | --------------------------------------------------- |
+| oelint-vscode.run.cache-path   | string        | ''          | Custom path to local caches                         |
+| oelint-vscode.run.cached       | boolean       | true        | run with local caches                               |
+| oelint-vscode.run.constantfile | string        | ''          | Path to constant file                               |
+| oelint-vscode.run.rulefile     | string        | .oelint.cfg | Path to rule file                                   |
+| oelint-vscode.run.extra-layer  | array[string] | []          | Extra layer constant data to load                   |
+| oelint-vscode.run.fix          | boolean       | false       | Automatically resolve fixable issues                |
+| oelint-vscode.run.mode         | string        | fast        | Mode to run in (fast or all)                        |
+| oelint-vscode.run.nobackup     | boolean       | true        | Don't create backups files while auto fixing        |
+| oelint-vscode.run.noinfo       | boolean       | false       | No info level issues                                |
+| oelint-vscode.run.nowarn       | boolean       | false       | No warning level issues                             |
+| oelint-vscode.run.release      | string        | ''          | Yocto project release name to use (default: latest) |
+| oelint-vscode.run.rules.custom | array[string] | []          | Additional paths to search for custom rules         |
+| oelint-vscode.run.rules.nonstd | array[string] | []          | Additional non-standard rulesets to load            |
+| oelint-vscode.run.suppress     | array[string] | []          | Error IDs to suppress automatically                 |
+| oelint-vscode.update.auto      | boolean       | true        | Automatically update oelint-adv tool                |
+| oelint-vscode.update.user      | boolean       | true        | Update with --user switch                           |

--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ so 99.9% of the credit go to them
 
 ## Configuration
 
-| key                            | type          | default     | description                                         |
-| ------------------------------ | ------------- | ----------- | --------------------------------------------------- |
-| oelint-vscode.run.cache-path   | string        | ''          | Custom path to local caches                         |
-| oelint-vscode.run.cached       | boolean       | true        | run with local caches                               |
-| oelint-vscode.run.constantfile | string        | ''          | Path to constant file                               |
-| oelint-vscode.run.rulefile     | string        | .oelint.cfg | Path to rule file                                   |
-| oelint-vscode.run.extra-layer  | array[string] | []          | Extra layer constant data to load                   |
-| oelint-vscode.run.fix          | boolean       | false       | Automatically resolve fixable issues                |
-| oelint-vscode.run.mode         | string        | fast        | Mode to run in (fast or all)                        |
-| oelint-vscode.run.nobackup     | boolean       | true        | Don't create backups files while auto fixing        |
-| oelint-vscode.run.noinfo       | boolean       | false       | No info level issues                                |
-| oelint-vscode.run.nowarn       | boolean       | false       | No warning level issues                             |
-| oelint-vscode.run.release      | string        | ''          | Yocto project release name to use (default: latest) |
-| oelint-vscode.run.rules.custom | array[string] | []          | Additional paths to search for custom rules         |
-| oelint-vscode.run.rules.nonstd | array[string] | []          | Additional non-standard rulesets to load            |
-| oelint-vscode.run.suppress     | array[string] | []          | Error IDs to suppress automatically                 |
-| oelint-vscode.update.auto      | boolean       | true        | Automatically update oelint-adv tool                |
-| oelint-vscode.update.user      | boolean       | true        | Update with --user switch                           |
+| key                            | type          | default | description                                         |
+| ------------------------------ | ------------- | ------- | --------------------------------------------------- |
+| oelint-vscode.run.cache-path   | string        | ''      | Custom path to local caches                         |
+| oelint-vscode.run.cached       | boolean       | true    | run with local caches                               |
+| oelint-vscode.run.constantfile | string        | ''      | Path to constant file                               |
+| oelint-vscode.run.rulefile     | string        | ''      | Path to rule file                                   |
+| oelint-vscode.run.extra-layer  | array[string] | []      | Extra layer constant data to load                   |
+| oelint-vscode.run.fix          | boolean       | false   | Automatically resolve fixable issues                |
+| oelint-vscode.run.mode         | string        | fast    | Mode to run in (fast or all)                        |
+| oelint-vscode.run.nobackup     | boolean       | true    | Don't create backups files while auto fixing        |
+| oelint-vscode.run.noinfo       | boolean       | false   | No info level issues                                |
+| oelint-vscode.run.nowarn       | boolean       | false   | No warning level issues                             |
+| oelint-vscode.run.release      | string        | ''      | Yocto project release name to use (default: latest) |
+| oelint-vscode.run.rules.custom | array[string] | []      | Additional paths to search for custom rules         |
+| oelint-vscode.run.rules.nonstd | array[string] | []      | Additional non-standard rulesets to load            |
+| oelint-vscode.run.suppress     | array[string] | []      | Error IDs to suppress automatically                 |
+| oelint-vscode.update.auto      | boolean       | true    | Automatically update oelint-adv tool                |
+| oelint-vscode.update.user      | boolean       | true    | Update with --user switch                           |

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
           "default": "",
           "description": "Path to constant file [DEPRECATED]"
         },
+        "oelint-vscode.run.rulefile": {
+          "type": "string",
+          "default": ".oelint.cfg",
+          "description": "Path to the rule file"
+        },
         "oelint-vscode.run.constmodadd": {
           "type": "array",
           "default": [],

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
         },
         "oelint-vscode.run.rulefile": {
           "type": "string",
-          "default": ".oelint.cfg",
+          "default": "",
           "description": "Path to the rule file"
         },
         "oelint-vscode.run.constmodadd": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lint your bitbake files",
   "license": "MIT",
   "homepage": "https://github.com/priv-kweihmann/oelint-vscode",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "publisher": "kweihmann",
   "repository": {
     "type": "git",

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -87,6 +87,9 @@ export default class Linter {
     if (config.get("oelint-vscode.run.constantfile")) {
       res.push("--constantfile=" + <string>(config.get("oelint-vscode.run.constantfile")));
     }
+    if (config.get("oelint-vscode.run.rulefile")) {
+      res.push("--rulefile=" + <string>(config.get("oelint-vscode.run.rulefile")));
+    }
     for (var opt of <Array<string>>config.get("oelint-vscode.run.constmodadd")) {
       res.push(`--constantmods=+${opt}`)
     }


### PR DESCRIPTION
As discussed in [issue #13 thread](https://github.com/priv-kweihmann/oelint-vscode/issues/13), provide a way to just check in a rule file so the oelint-adv CLI can share an authoritative config with the vscode editors.

resolves #13