### PR TITLE
fix: Previous PR always opened output pane

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,21 +49,18 @@ export function activate(context: vscode.ExtensionContext) {
   output.appendLine('oelint-adv extension activated');
   logOelintVersion(output);
 
-  let events = vscode.commands.registerCommand(commandId, () => {
-    vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
-      if(document.languageId !== 'bitbake') {
-        return;
-      }
+  const saveListener = vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
+    if (document.languageId !== 'bitbake') {
+      return;
+    }
 
-      output.appendLine(`Linting on save: ${document.uri.fsPath}`);
-      output.show(true);
-      doLint(document, diagnosticCollection, output);
-    });
+    output.appendLine(`Linting on save: ${document.uri.fsPath}`);
+    void doLint(document, diagnosticCollection, output);
   });
 
-  vscode.commands.executeCommand(commandId);
-  context.subscriptions.push(events);
+  context.subscriptions.push(saveListener);
   context.subscriptions.push(output);
+  context.subscriptions.push(diagnosticCollection);
 
   // do auto update
   doUpdate();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,16 @@
+import * as cp from 'child_process';
+import * as util from 'util';
 import * as vscode from 'vscode';
 import Linter, { LinterError } from './linter';
 
-async function doLint(codeDocument: vscode.TextDocument, collection: vscode.DiagnosticCollection): Promise<void> {
-  const linter = new Linter(codeDocument);
+async function doLint(
+  codeDocument: vscode.TextDocument,
+  collection: vscode.DiagnosticCollection,
+  output: vscode.OutputChannel
+): Promise<void> {
+  const linter = new Linter(codeDocument, output);
   const errors: LinterError[] = await linter.lint();
+  output.appendLine(`Parsed errors: ${errors.length}`);
 
   const uniqueFiles: string[] = errors.map(f => { return f.proto.file });
 
@@ -28,9 +35,19 @@ async function doUpdate(): Promise<void> {
   Linter.update();
 }
 
+async function logOelintVersion(output: vscode.OutputChannel): Promise<void> {
+  const exec = util.promisify(cp.exec);
+  await exec("oelint-adv --version")
+    .then((result: { stdout: string }) => output.appendLine(`oelint-adv version: ${result.stdout.trim()}`))
+    .catch(() => output.appendLine("oelint-adv version: unknown"));
+}
+
 export function activate(context: vscode.ExtensionContext) {
   const commandId = 'extension.oelint';
   const diagnosticCollection = vscode.languages.createDiagnosticCollection(commandId);
+  const output = vscode.window.createOutputChannel('oelint-adv');
+  output.appendLine('oelint-adv extension activated');
+  logOelintVersion(output);
 
   let events = vscode.commands.registerCommand(commandId, () => {
     vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
@@ -38,12 +55,15 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       }
 
-      doLint(document, diagnosticCollection);
+      output.appendLine(`Linting on save: ${document.uri.fsPath}`);
+      output.show(true);
+      doLint(document, diagnosticCollection, output);
     });
   });
 
   vscode.commands.executeCommand(commandId);
   context.subscriptions.push(events);
+  context.subscriptions.push(output);
 
   // do auto update
   doUpdate();

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -10,9 +10,11 @@ export interface LinterError {
 
 export default class Linter {
   private codeDocument: vscode.TextDocument;
+  private output?: vscode.OutputChannel;
 
-  constructor(document: vscode.TextDocument) {
+  constructor(document: vscode.TextDocument, output?: vscode.OutputChannel) {
     this.codeDocument = document;
+    this.output = output;
   }
 
   public static update(): void {
@@ -120,14 +122,19 @@ export default class Linter {
     const exec = util.promisify(cp.exec);
     const addopt = this.createAdditionalConfig().join(" ")
     const cmd = `oelint-adv ${addopt} ${currentFile}`;
-
+    this.output?.appendLine(`Executing: ${cmd}`);
     let lintResults: string = "";
     const curdir = process.cwd()
 
     if (curdir != wspath) {
       process.chdir(wspath)
     }
-    await exec(cmd).catch((error: any) => lintResults = error.stderr);
+    await exec(cmd)
+      .then(() => this.output?.appendLine("Linting successful"))
+      .catch((error: any) => {
+        lintResults = error.stderr;
+        this.output?.appendLine("Linting failed");
+      });
 
     process.chdir(curdir)
 


### PR DESCRIPTION
The previous PR https://github.com/priv-kweihmann/oelint-vscode/pull/15 always opened the output pane on each save. This PR fixes this, but keeps the logging